### PR TITLE
Release v1.0.0

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,11 +1,16 @@
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
 name: PR Checks
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - name: markdown-link-check
+    - name: informal-markdown-link-check
       uses: ./
       with:
         check-modified-files-only: 'yes'
@@ -13,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - name: markdown-link-check
+    - name: informal-markdown-link-check
       uses: ./
       with:
         # Add a test to restrict the test to just dir4 and dir5.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # GitHub Action - Markdown link check 🔗✔️
-[![GitHub Marketplace](https://img.shields.io/badge/GitHub%20Marketplace-Markdown%20link%20check-brightgreen?style=for-the-badge)](https://github.com/marketplace/actions/markdown-link-check)
 
-This GitHub action checks all Markdown files in your repository for broken links. (Uses [tcort/markdown-link-check](https://github.com/tcort/markdown-link-check))
+This is a fork of
+<https://github.com/gaurav-nelson/github-action-markdown-link-check>.
+
+This GitHub action checks all Markdown files in your repository for broken
+links. (Uses
+[tcort/markdown-link-check](https://github.com/tcort/markdown-link-check))
 
 ## How to use
 1. Create a new file in your repository `.github/workflows/action.yml`.
@@ -17,23 +21,8 @@ This GitHub action checks all Markdown files in your repository for broken links
        runs-on: ubuntu-latest
        steps:
        - uses: actions/checkout@master
-       - uses: gaurav-nelson/github-action-markdown-link-check@v1
+       - uses: informalsystems/github-action-markdown-link-check@v1
    ```
-
-### Real-life usage samples
-
-Following is a list of some of the repositories which are using GitHub Action -
-Markdown link check.
-
-1. [netdata](https://github.com/netdata/netdata/blob/master/.github/workflows/docs.yml) ![](https://img.shields.io/github/stars/netdata/netdata?style=social)
-1. [GoogleChrome/lighthouse (Weekly cron job)](https://github.com/GoogleChrome/lighthouse/blob/master/.github/workflows/cron-weekly.yml)
-   ![](https://img.shields.io/github/stars/GoogleChrome/lighthouse?style=social)
-1. [tendermint/tendermint](https://github.com/tendermint/tendermint/blob/master/.github/workflows/markdown-links.yml)
-   ![](https://img.shields.io/github/stars/tendermint/tendermint?style=social)
-1. [pyroscope-io/pyroscope](https://github.com/pyroscope-io/pyroscope/blob/main/.github/workflows/lint-markdown.yml)
-   ![](https://img.shields.io/github/stars/pyroscope-io/pyroscope?style=social)
-
-If you are using this on production, consider [buying me a coffee](https://ko-fi.com/gauravnelson) ☕.
 
 ## Configuration
 
@@ -55,7 +44,7 @@ You customize the action by using the following variables:
 |`folder-path` |By default the `github-action-markdown-link-check` action checks for all markdown files in your repository. Use this option to limit checks to only specific folders. Use comma separated values for checking multiple folders. |`.` |
 |`max-depth` |Specify how many levels deep you want to check in the directory structure. The default value is `-1` which means check all levels.|`-1` |
 |`check-modified-files-only` |Use this variable to only check modified markdown files instead of checking all markdown files. The action uses `git` to find modified markdown files. Only use this variable when you run the action to check pull requests.|`no`|
-|`base-branch`|Use this variable to specify the branch to compare when finding modified markdown files. |`master`|
+|`base-branch`|Use this variable to specify the branch to compare when finding modified markdown files. |`main`|
 |`file-extension`|By default the `github-action-markdown-link-check` action checks files in your repository with the `.md` extension. Use this option to specify a different file extension such as `.markdown` or `.mdx`.|`.md`|
 |`file-path` | Specify additional files (with complete path and extension) you want to check. Use comma separated values for checking multiple files. See [Check multiple directories and files](#check-multiple-directories-and-files) section for usage.| - |
 
@@ -71,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+    - uses: informalsystems/github-action-markdown-link-check@v1
       with:
         use-quiet-mode: 'yes'
         use-verbose-mode: 'yes'
@@ -94,7 +83,7 @@ name: Check Markdown links
 on:
   push:
     branches:
-    - master
+    - main
   schedule:
   # Run everyday at 9:00 AM (See https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#tag_20_25_07)
   - cron: "0 9 * * *"
@@ -104,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+    - uses: informalsystems/github-action-markdown-link-check@v1
       with:
         use-quiet-mode: 'yes'
         use-verbose-mode: 'yes'
@@ -138,7 +127,7 @@ pull request.
 When
 you use this variable, the action finds modififed files between two commits:
 - latest commit in you PR
-- latest commit in the `master` branch. If you are suing a different branch to
+- latest commit in the `main` branch. If you are suing a different branch to
   merge PRs, specify the branch using `base-branch`.
 
 > **NOTE**: We can also use GitHub API to get all modified files in a PR, but that
@@ -152,7 +141,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+    - uses: informalsystems/github-action-markdown-link-check@v1
       with:
         use-quiet-mode: 'yes'
         use-verbose-mode: 'yes'
@@ -170,7 +159,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+    - uses: informalsystems/github-action-markdown-link-check@v1
       with:
         use-quiet-mode: 'yes'
         folder-path: 'md/dir1, md/dir2'
@@ -178,8 +167,9 @@ jobs:
 ```
 
 ### Too many requests
-Use `retryOn429`, `retry-after`, `retryCount`, and `fallbackRetryDelay` in your custom configuration file.
-See https://github.com/tcort/markdown-link-check#config-file-format for details.
+Use `retryOn429`, `retry-after`, `retryCount`, and `fallbackRetryDelay` in your
+custom configuration file. See
+<https://github.com/tcort/markdown-link-check#config-file-format> for details.
 
 Or mark 429 status code as alive:
 ```json
@@ -206,13 +196,13 @@ Use the folliwng `httpHeaders` in your custom configuration file to fix GitHub l
 
 ## Example Usage
 
-Consider a workflow file that checks for the status of hyperlinks on push to the master branch,
+Consider a workflow file that checks for the status of hyperlinks on push to the main branch,
 
 ``` yml
 name: Check .md links
 
 on:
-  push: [master]
+  push: [main]
 
 jobs:
   markdown-link-check:
@@ -223,7 +213,7 @@ jobs:
 
     # Checks the status of hyperlinks in .md files in verbose mode
     - name: Check links
-      uses: gaurav-nelson/github-action-markdown-link-check@v1
+      uses: informalsystems/github-action-markdown-link-check@v1
       with:
         use-verbose-mode: 'yes'
 ```
@@ -237,24 +227,22 @@ On running the workflow described above, the output shown below is obtained
 
 
 ## Versioning
-GitHub Action - Markdown link check follows the [GitHub recommended versioning strategy](https://github.com/actions/toolkit/blob/master/docs/action-versioning.md).
 
-1. To use a specific released version of the action ([Releases](https://github.com/gaurav-nelson/github-action-markdown-link-check/releases)):
-   ```yml
-   - uses: gaurav-nelson/github-action-markdown-link-check@1.0.1
-   ```
-1. To use a major version of the action:
-   ```yml
-   - uses: gaurav-nelson/github-action-markdown-link-check@v1
-   ```
-1. You can also specify a [specific commit SHA](https://github.com/gaurav-nelson/github-action-markdown-link-check/commits/master) as an action version:
-   ```yml
-   - uses: gaurav-nelson/github-action-markdown-link-check@44a942b2f7ed0dc101d556f281e906fb79f1f478
-   ```
+GitHub Action - Markdown link check follows the [GitHub recommended versioning
+strategy](https://github.com/actions/toolkit/blob/master/docs/action-versioning.md).
 
-<hr>
-<p align="center">
- <a name="coffee" href="https://ko-fi.com/gauravnelson">
-  <img src="https://i.imgur.com/1Q1YoHz.gif" alt="Buy me a coffee.">
- </a>
-</p>
+1. To use a specific released version of the action
+   ([Releases](https://github.com/informalsystems/github-action-markdown-link-check/releases)):
+   ```yml
+   - uses: informalsystems/github-action-markdown-link-check@1.0.1
+   ```
+2. To use a major version of the action:
+   ```yml
+   - uses: informalsystems/github-action-markdown-link-check@v1
+   ```
+3. You can also specify a [specific commit
+   SHA](https://github.com/informalsystems/github-action-markdown-link-check/commits/main)
+   as an action version:
+   ```yml
+   - uses: informalsystems/github-action-markdown-link-check@44a942b2f7ed0dc101d556f281e906fb79f1f478
+   ```

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'markdown-link-check'
+name: 'informal-markdown-link-check'
 description: 'Check if all links are valid in markdown files.'
 author: 'Gaurav Nelson'
 branding:
@@ -33,9 +33,9 @@ inputs:
     default: 'no'
   base-branch:
     description: 'Use this to specify the base branch against which the action
-    finds the modififed files.'
+    finds the modified files.'
     required: true
-    default: 'master'
+    default: 'main'
   file-extension:
     description: 'Use this to specify the file extension of Markdown files.'
     required: true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,7 @@ YELLOW='\033[0;33m'
 BLUE='\033[0;34m'
 RED='\033[0;31m'
 
-npm i -g markdown-link-check@3.10.2
+npm i -g markdown-link-check@3.10.3
 echo "::group::Debug information"
 npm -g list --depth=1
 echo "::endgroup::"

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -3,5 +3,16 @@
         {
             "pattern": "^http://ignored-domain.com"
         }
+    ],
+    "httpHeaders": [
+        {
+            "urls": [
+                "https://docs.github.com/",
+                "https://help.github.com/"
+            ],
+            "headers": {
+                "Accept-Encoding": "zstd, br, gzip, deflate"
+            }
+        }
     ]
 }


### PR DESCRIPTION
Releases the first version of the `informal-markdown-link-check` action - a fork of https://github.com/gaurav-nelson/github-action-markdown-link-check that we can version ourselves, since it's not clear whether the upstream author will be cutting new releases or keeping it up-to-date.